### PR TITLE
Update readme to describe usages in latest mps

### DIFF
--- a/.mps/migration.xml
+++ b/.mps/migration.xml
@@ -5,5 +5,7 @@
     <entry key="jetbrains.mps.ide.mpsmigration.v191.SaveAllJavaStubMethodRefsToShortForeignFormat" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v191.UpdateJavaStubMethodRefs" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
+    <entry key="project.migrated.version" value="212" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -4,8 +4,18 @@ This repository contains a MPS implementation of the [CrySL](https://www.eclipse
 
 ## Dependencies
 
-To build the language, [mbeddr-platform](https://build.mbeddr.com/viewType.html?buildTypeId=Mbeddr2_Mbeddr_Gradle_platform) needs to be accessible by MPS.
+To build the language, parts of the [mbeddr-platform](https://build.mbeddr.com/viewType.html?buildTypeId=Mbeddr2_Mbeddr_Gradle_platform) need to be accessible by MPS.
+
+In recent MPS versions, necessary components may be installed as plugins from the JetBrains marketplace.
+In MPS go to `File`, `Settings` and `Plugins`. Then, search for and install the following plugins:
+
+- [`de.itemis.mps.editor.diagram`](https://plugins.jetbrains.com/plugin/13240-de-itemis-mps-editor-diagram)
+- [`com.mbeddr.mpsutil.modellisteners`](https://plugins.jetbrains.com/plugin/17130-com-mbeddr-mpsutil-modellisteners)
+- [`de.itemis.mps.grammarcells`](https://plugins.jetbrains.com/plugin/13242-de-itemis-mps-grammarcells)
+
+When prompted to install additional dependencies, accept that option.
+Finally, restart MPS and re-open this project to be ready to use it!
 
 ## MPS Version
 
-Currently the project still runs on the old 2020.3 version of MPS due to the iets3.opensource dependency not supporting any newer version so far.
+The project is known to work on MPS version 2021.2.1 when installing mentioned dependencies from the plugin marketplace.

--- a/sandbox/CryslMPS.sandbox.msd
+++ b/sandbox/CryslMPS.sandbox.msd
@@ -13,7 +13,6 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
-    <dependency reexport="false">7f0984ac-9f5d-4001-9257-17f7d10f3fd5(com.mbeddr.mpsutil.httpsupport.rt)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:8e9fbf67-e9d6-4aec-bf8d-e721059602cb:CryslMPS" version="0" />
@@ -42,7 +41,6 @@
     <language slang="l:d09a16fb-1d68-4a92-a5a4-20b4b2f86a62:com.mbeddr.mpsutil.jung" version="0" />
     <language slang="l:b4d28e19-7d2d-47e9-943e-3a41f97a0e52:com.mbeddr.mpsutil.plantuml.node" version="0" />
     <language slang="l:8ca79d43-eb45-4791-bdd4-0d6130ff895b:de.itemis.mps.editor.diagram.layout" version="0" />
-    <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />

--- a/sandbox/models/CryslMPS.sandbox.mps
+++ b/sandbox/models/CryslMPS.sandbox.mps
@@ -16,7 +16,6 @@
     <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />
     <import index="n3z7" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.net.ssl(JDK/)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
-    <import index="nwfd" ref="7f0984ac-9f5d-4001-9257-17f7d10f3fd5/java:javax.servlet.http(com.mbeddr.mpsutil.httpsupport.rt/)" />
     <import index="2t8e" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.xml.crypto.dsig.spec(JDK/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="6nfx" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.security.auth.x500(JDK/)" />
@@ -36,9 +35,6 @@
         <child id="1070534760952" name="componentType" index="10Q1$1" />
       </concept>
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
-        <property id="1068580123138" name="value" index="3clFbU" />
-      </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -4529,84 +4525,6 @@
             <ref role="gkoRJ" node="77$2yxitnNC" resolve="ciph" />
           </node>
         </node>
-      </node>
-    </node>
-  </node>
-  <node concept="3DZmox" id="77$2yxito8h">
-    <property role="TrG5h" value="Cookie" />
-    <node concept="3uibUv" id="77$2yxito8i" role="1yEc0o">
-      <ref role="3uigEE" to="nwfd:~Cookie" resolve="Cookie" />
-    </node>
-    <node concept="3DZmoB" id="77$2yxito8j" role="3DZmv6">
-      <node concept="2Hjy6O" id="77$2yxitoYB" role="3DZmuy">
-        <property role="TrG5h" value="cookieName" />
-        <node concept="17QB3L" id="77$2yxitoYA" role="2HiiPi" />
-      </node>
-      <node concept="2Hjy6O" id="77$2yxitoYO" role="3DZmuy">
-        <property role="TrG5h" value="cookieValue" />
-        <node concept="17QB3L" id="77$2yxitoYM" role="2HiiPi" />
-      </node>
-      <node concept="2Hjy6O" id="77$2yxitoZ7" role="3DZmuy">
-        <property role="TrG5h" value="secure" />
-        <node concept="10P_77" id="77$2yxitoZ5" role="2HiiPi" />
-      </node>
-    </node>
-    <node concept="3DZmo_" id="77$2yxito8k" role="3DZmv4">
-      <node concept="3DZmon" id="77$2yxitoZU" role="3DZmuH">
-        <property role="TrG5h" value="Con" />
-        <node concept="gjU3G" id="77$2yxitoZV" role="gjZaj">
-          <ref role="gjVmy" to="nwfd:~Cookie.&lt;init&gt;(java.lang.String,java.lang.String)" resolve="Cookie" />
-          <node concept="3DZmol" id="77$2yxitp02" role="gjVns">
-            <node concept="gkoRC" id="77$2yxitp00" role="gkqJZ">
-              <ref role="gkoRJ" node="77$2yxitoYB" resolve="cookieName" />
-            </node>
-          </node>
-          <node concept="3DZmol" id="77$2yxitp0o" role="gjVns">
-            <node concept="gkoRC" id="77$2yxitp0m" role="gkqJZ">
-              <ref role="gkoRJ" node="77$2yxitoYO" resolve="cookieValue" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="20kzeY" id="77$2yxitp0J" role="3DZmuH" />
-      <node concept="3DZmon" id="77$2yxitp1T" role="3DZmuH">
-        <property role="TrG5h" value="SetSecure" />
-        <node concept="gjU3G" id="77$2yxitp1U" role="gjZaj">
-          <ref role="gjVmy" to="nwfd:~Cookie.setSecure(boolean)" resolve="setSecure" />
-          <node concept="3DZmol" id="77$2yxitp2c" role="gjVns">
-            <node concept="gkoRC" id="77$2yxitp2a" role="gkqJZ">
-              <ref role="gkoRJ" node="77$2yxitoZ7" resolve="secure" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1h0U3S" id="77$2yxito8l" role="3DZmuV">
-      <node concept="1y6fP7" id="77$2yxitp2r" role="2HaykH">
-        <node concept="1y6fSb" id="77$2yxitp2y" role="1y6fPo">
-          <ref role="1y6fS8" node="77$2yxitp1T" resolve="SetSecure" />
-        </node>
-        <node concept="1y6fSb" id="77$2yxitp2n" role="1y6fQO">
-          <ref role="1y6fS8" node="77$2yxitoZU" resolve="Con" />
-        </node>
-      </node>
-    </node>
-    <node concept="3DZmo$" id="77$2yxitp2_" role="3DZmuU">
-      <node concept="2CQV6U" id="77$2yxitp30" role="3DZmuY">
-        <node concept="2$dyII" id="77$2yxitp3f" role="2CQV6T">
-          <node concept="3clFbT" id="77$2yxitp3_" role="1ysvkh">
-            <property role="3clFbU" value="true" />
-          </node>
-          <node concept="gkoRC" id="77$2yxitp2Z" role="1ysvk5">
-            <ref role="gkoRJ" node="77$2yxitoZ7" resolve="secure" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3DZmoq" id="77$2yxitp3H" role="3DZmuS">
-      <node concept="3kw8lT" id="77$2yxitp3N" role="3DZmv1">
-        <property role="TrG5h" value="generatedCookie" />
-        <node concept="3kw8PP" id="77$2yxitp3R" role="3kw8l0" />
       </node>
     </node>
   </node>


### PR DESCRIPTION
I had some issues installing the mbeddr platform into my MPS, but I found an alternative to get this project running without manually downloading plugins. This may be easier for other novice MPS users too, so maybe it could be pointed out in the readme.

Parts of the mbeddr platform are now made available in the [MPS extensions](https://jetbrains.github.io/MPS-extensions/) project, which JetBrains helps maintain. In particular, this is true for the diagram and modellisteners extensions used by CrySL MPS.

Unfortunately, the `com.mbeddr.mpsutil.httpsupport.rt` dependency has not been migrated to the MPS extensions project (yet?). But it looks like it's only used in the sandbox project, and I didn't fully understand why. Is it solely for the `Cookie` rule?